### PR TITLE
 implement show_chunks in C and have drop_chunks use it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ typedef.list
 **/GRTAGS
 **/GSYMS
 /.vs
+compile_commands.json

--- a/sql/ddl_api.sql
+++ b/sql/ddl_api.sql
@@ -20,7 +20,7 @@ CREATE OR REPLACE FUNCTION  create_hypertable(
     number_partitions       INTEGER = NULL,
     associated_schema_name  NAME = NULL,
     associated_table_prefix NAME = NULL,
-    chunk_time_interval     anyelement = NULL::bigint,
+    chunk_time_interval     ANYELEMENT = NULL::bigint,
     create_default_indexes  BOOLEAN = TRUE,
     if_not_exists           BOOLEAN = FALSE,
     partitioning_func       REGPROC = NULL,
@@ -47,69 +47,43 @@ CREATE OR REPLACE FUNCTION  set_number_partitions(
     dimension_name          NAME = NULL
 ) RETURNS VOID AS '@MODULE_PATHNAME@', 'dimension_set_num_slices' LANGUAGE C VOLATILE;
 
--- Drop chunks that are older than a timestamp.
+-- Drop chunks that are older than a timestamp or newer than a timestamp.
 CREATE OR REPLACE FUNCTION drop_chunks(
-    older_than anyelement,
+    older_than ANYELEMENT = NULL,
     table_name  NAME = NULL,
     schema_name NAME = NULL,
-    cascade  BOOLEAN = FALSE
+    cascade  BOOLEAN = FALSE,
+    newer_than ANYELEMENT = NULL
 )
     RETURNS VOID LANGUAGE PLPGSQL VOLATILE AS
 $BODY$
 DECLARE
     older_than_internal BIGINT;
+    newer_than_internal BIGINT;
 BEGIN
-    IF older_than IS NULL THEN
-        RAISE 'the timestamp provided to drop_chunks cannot be NULL';
+    IF older_than IS NULL AND newer_than IS NULL THEN
+        RAISE 'Both older_than and newer_than timestamps provided to drop_chunks cannot be NULL';
     END IF;
-
-    PERFORM  _timescaledb_internal.drop_chunks_type_check(pg_typeof(older_than), table_name, schema_name);
-    SELECT _timescaledb_internal.time_to_internal(older_than, pg_typeof(older_than)) INTO older_than_internal;
-    PERFORM _timescaledb_internal.drop_chunks_impl(older_than_internal, table_name, schema_name, cascade);
+    PERFORM _timescaledb_internal.drop_chunks_impl(older_than, table_name, schema_name, cascade,
+    truncate_before => FALSE, newer_than_time => newer_than);
 END
 $BODY$;
 
--- Drop chunks older than an interval.
-CREATE OR REPLACE FUNCTION drop_chunks(
-    older_than  INTERVAL,
-    table_name  NAME = NULL,
-    schema_name NAME = NULL,
-    cascade BOOLEAN = false
-)
-    RETURNS VOID LANGUAGE PLPGSQL VOLATILE AS
-$BODY$
-DECLARE
-    time_type REGTYPE;
-BEGIN
-
-    BEGIN
-        WITH hypertable_ids AS (
-            SELECT id
-            FROM _timescaledb_catalog.hypertable h
-            WHERE (drop_chunks.schema_name IS NULL OR h.schema_name = drop_chunks.schema_name) AND
-            (drop_chunks.table_name IS NULL OR h.table_name = drop_chunks.table_name)
-        )
-        SELECT DISTINCT time_dim.column_type INTO STRICT time_type
-        FROM hypertable_ids INNER JOIN LATERAL _timescaledb_internal.dimension_get_time(hypertable_ids.id) time_dim ON (true);
-    EXCEPTION
-        WHEN NO_DATA_FOUND THEN
-            RAISE EXCEPTION 'no hypertables found';
-        WHEN TOO_MANY_ROWS THEN
-            RAISE EXCEPTION 'cannot use drop_chunks on multiple tables with different time types';
-    END;
-
-
-    IF time_type = 'TIMESTAMP'::regtype THEN
-        PERFORM @extschema@.drop_chunks((now() - older_than)::timestamp, table_name, schema_name, cascade);
-    ELSIF time_type = 'DATE'::regtype THEN
-        PERFORM @extschema@.drop_chunks((now() - older_than)::date, table_name, schema_name, cascade);
-    ELSIF time_type = 'TIMESTAMPTZ'::regtype THEN
-        PERFORM @extschema@.drop_chunks(now() - older_than, table_name, schema_name, cascade);
-    ELSE
-        RAISE 'can only use drop_chunks with an INTERVAL for TIMESTAMP, TIMESTAMPTZ, and DATE types';
-    END IF;
-END
-$BODY$;
+-- show chunks older than or newer than a specific time.
+-- hypertable_name can be a valid hypertable or NULL.
+-- In the latter case the function will try to list all
+-- the chunks from all of the hypertables in the database.
+-- older_than or newer_than or both can be NULL.
+-- if hypertable_name is null but a time constraint is specified
+-- through older_than or newer_than, the call will succeed
+-- if and only if all the hypertables in the database
+-- have the same type as the given time constraint argument
+CREATE OR REPLACE FUNCTION show_chunks(
+    hypertable_name  REGCLASS = NULL,
+    older_than "any" = NULL,
+    newer_than "any" = NULL
+) RETURNS SETOF REGCLASS AS '@MODULE_PATHNAME@', 'chunk_show_chunks'
+LANGUAGE C STABLE PARALLEL SAFE;
 
 -- Add a dimension (of partitioning) to a hypertable
 --

--- a/sql/ddl_internal.sql
+++ b/sql/ddl_internal.sql
@@ -1,34 +1,33 @@
-CREATE OR REPLACE FUNCTION _timescaledb_internal.dimension_get_time(
-    hypertable_id INT
-)
-    RETURNS _timescaledb_catalog.dimension LANGUAGE SQL STABLE AS
-$BODY$
-    SELECT *
-    FROM _timescaledb_catalog.dimension d
-    WHERE d.hypertable_id = dimension_get_time.hypertable_id AND
-          d.interval_length IS NOT NULL
-$BODY$;
+-- show_chunks for internal use only. The only difference
+-- from user-facing API is that this one takes a 4th argument
+-- specifying the caller name. This makes it easier to taylor
+-- error messages to the caller function context.
+CREATE OR REPLACE FUNCTION _timescaledb_internal.show_chunks_impl(
+    hypertable_name  REGCLASS = NULL,
+    older_than "any" = NULL,
+    newer_than "any" = NULL,
+    caller_name NAME = NULL
+) RETURNS SETOF REGCLASS AS '@MODULE_PATHNAME@', 'chunk_show_chunks'
+LANGUAGE C STABLE PARALLEL SAFE;
 
 -- Drop chunks older than the given timestamp. If a hypertable name is given,
 -- drop only chunks associated with this table. Any of the first three arguments
 -- can be NULL meaning "all values".
 CREATE OR REPLACE FUNCTION _timescaledb_internal.drop_chunks_impl(
-    older_than_time  BIGINT,
+    older_than_time  ANYELEMENT = NULL,
     table_name  NAME = NULL,
     schema_name NAME = NULL,
     cascade  BOOLEAN = FALSE,
-    truncate_before  BOOLEAN = FALSE
+    truncate_before  BOOLEAN = FALSE,
+    newer_than_time ANYELEMENT = NULL
 )
     RETURNS VOID LANGUAGE PLPGSQL VOLATILE AS
 $BODY$
 DECLARE
-    chunk_row _timescaledb_catalog.chunk;
+    chunk_row REGCLASS;
     cascade_mod TEXT = '';
     exist_count INT = 0;
 BEGIN
-    IF older_than_time IS NULL AND table_name IS NULL AND schema_name IS NULL THEN
-        RAISE 'cannot have all 3 arguments to drop_chunks_older_than be NULL';
-    END IF;
 
     IF cascade THEN
         cascade_mod = 'CASCADE';
@@ -47,68 +46,29 @@ BEGIN
         END IF;
     END IF;
 
-    FOR chunk_row IN SELECT *
-        FROM _timescaledb_catalog.chunk c
-        INNER JOIN _timescaledb_catalog.hypertable h ON (h.id = c.hypertable_id)
-        INNER JOIN _timescaledb_internal.dimension_get_time(h.id) time_dimension ON(true)
-        INNER JOIN _timescaledb_catalog.dimension_slice ds
-            ON (ds.dimension_id = time_dimension.id)
-        INNER JOIN _timescaledb_catalog.chunk_constraint cc
-            ON (cc.dimension_slice_id = ds.id AND cc.chunk_id = c.id)
-        WHERE (older_than_time IS NULL OR ds.range_end <= older_than_time)
-        AND (drop_chunks_impl.schema_name IS NULL OR h.schema_name = drop_chunks_impl.schema_name)
-        AND (drop_chunks_impl.table_name IS NULL OR h.table_name = drop_chunks_impl.table_name)
+    FOR schema_name, table_name IN
+        SELECT hyper.schema_name, hyper.table_name
+        FROM _timescaledb_catalog.hypertable hyper
+        WHERE
+            (drop_chunks_impl.schema_name IS NULL OR hyper.schema_name = drop_chunks_impl.schema_name) AND
+            (drop_chunks_impl.table_name IS NULL OR hyper.table_name = drop_chunks_impl.table_name)
     LOOP
-        IF truncate_before THEN
+        FOR chunk_row IN SELECT _timescaledb_internal.show_chunks_impl(schema_name || '.' || table_name, older_than_time, newer_than_time, 'drop_chunks')
+        LOOP
+            IF truncate_before THEN
+                EXECUTE format(
+                    $$
+                    TRUNCATE %s %s
+                    $$, chunk_row, cascade_mod
+                );
+            END IF;
             EXECUTE format(
-                $$
-                TRUNCATE %I.%I %s
-                $$, chunk_row.schema_name, chunk_row.table_name, cascade_mod
+                    $$
+                    DROP TABLE %s %s
+                    $$, chunk_row, cascade_mod
             );
-        END IF;
-        EXECUTE format(
-                $$
-                DROP TABLE %I.%I %s
-                $$, chunk_row.schema_name, chunk_row.table_name, cascade_mod
-        );
+        END LOOP;
     END LOOP;
-END
-$BODY$;
-
-CREATE OR REPLACE FUNCTION _timescaledb_internal.drop_chunks_type_check(
-    given_type REGTYPE,
-    table_name  NAME,
-    schema_name NAME
-)
-    RETURNS VOID LANGUAGE PLPGSQL STABLE AS
-$BODY$
-DECLARE
-    actual_type regtype;
-BEGIN
-    BEGIN
-        WITH hypertable_ids AS (
-            SELECT id
-            FROM _timescaledb_catalog.hypertable h
-            WHERE (drop_chunks_type_check.schema_name IS NULL OR h.schema_name = drop_chunks_type_check.schema_name) AND
-            (drop_chunks_type_check.table_name IS NULL OR h.table_name = drop_chunks_type_check.table_name)
-        )
-        SELECT DISTINCT time_dim.column_type INTO STRICT actual_type
-        FROM hypertable_ids INNER JOIN LATERAL _timescaledb_internal.dimension_get_time(hypertable_ids.id) time_dim ON (true);
-    EXCEPTION
-        WHEN NO_DATA_FOUND THEN
-            RAISE EXCEPTION 'no hypertables found';
-        WHEN TOO_MANY_ROWS THEN
-            RAISE EXCEPTION 'cannot use drop_chunks on multiple tables with different time types';
-    END;
-
-    IF given_type IN ('int'::regtype, 'smallint'::regtype, 'bigint'::regtype ) THEN
-        IF actual_type IN ('int'::regtype, 'smallint'::regtype, 'bigint'::regtype ) THEN
-            RETURN;
-        END IF;
-    END IF;
-    IF actual_type != given_type THEN
-        RAISE EXCEPTION 'cannot call drop_chunks with a % on hypertables with a time type of: %', given_type, actual_type;
-    END IF;
 END
 $BODY$;
 

--- a/src/catalog.c
+++ b/src/catalog.c
@@ -11,7 +11,6 @@
 #include <miscadmin.h>
 #include <commands/dbcommands.h>
 #include <commands/sequence.h>
-#include <access/xact.h>
 
 #include "compat.h"
 #include "catalog.h"

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -66,6 +66,7 @@ extern Chunk *chunk_create(Hypertable *ht, Point *p, const char *schema, const c
 extern Chunk *chunk_create_stub(int32 id, int16 num_constraints);
 extern void chunk_free(Chunk *chunk);
 extern Chunk *chunk_find(Hyperspace *hs, Point *p);
+extern List *chunks_find_all_in_range_limit(Hyperspace *hs, StrategyNumber start_strategy, int64 start_value, StrategyNumber end_strategy, int64 end_value, int limit);
 extern List *chunk_find_all_oids(Hyperspace *hs, List *dimension_vecs, LOCKMODE lockmode);
 extern Chunk *chunk_copy(Chunk *chunk);
 extern Chunk *chunk_get_by_name_with_memory_context(const char *schema_name, const char *table_name, int16 num_constraints, MemoryContext mctx, bool fail_if_not_found);

--- a/src/dimension.h
+++ b/src/dimension.h
@@ -94,6 +94,15 @@ typedef struct DimensionInfo
 	 (di)->colname != NULL &&											\
 	 ((di)->num_slices_is_set || OidIsValid((di)->interval_datum)))
 
+#define IS_INTEGER_TYPE(type)							\
+	(type == INT2OID || type == INT4OID || type == INT8OID)
+
+#define IS_TIMESTAMP_TYPE(type)									\
+	(type == TIMESTAMPOID || type == TIMESTAMPTZOID || type == DATEOID)
+
+#define IS_VALID_OPEN_DIM_TYPE(type)					\
+	(IS_INTEGER_TYPE(type) || IS_TIMESTAMP_TYPE(type))
+
 extern Hyperspace *dimension_scan(int32 hypertable_id, Oid main_table_relid, int16 num_dimension, MemoryContext mctx);
 extern DimensionSlice *dimension_calculate_default_slice(Dimension *dim, int64 value);
 extern Point *hyperspace_calculate_point(Hyperspace *h, HeapTuple tuple, TupleDesc tupdesc);

--- a/src/dimension_slice.c
+++ b/src/dimension_slice.c
@@ -173,7 +173,7 @@ dimension_slice_scan_limit(int32 dimension_id, int64 coordinate, int limit)
 }
 
 /*
- * Look for all ranges where value > lower_bound and value < upper_bound
+ * Look for all dimension slices where (lower_bound, upper_bound) of the dimension_slice contains the given (start_value, end_value) range
  *
  */
 DimensionVec *

--- a/src/dimension_slice.h
+++ b/src/dimension_slice.h
@@ -27,7 +27,6 @@ typedef struct Hypercube Hypercube;
 extern DimensionVec *dimension_slice_scan_limit(int32 dimension_id, int64 coordinate, int limit);
 extern DimensionVec *dimension_slice_scan_range_limit(int32 dimension_id, StrategyNumber start_strategy, int64 start_value, StrategyNumber end_strategy, int64 end_value, int limit);
 extern DimensionVec *dimension_slice_collision_scan_limit(int32 dimension_id, int64 range_start, int64 range_end, int limit);
-extern Hypercube *dimension_slice_point_scan(Hyperspace *space, int64 point[]);
 extern DimensionSlice *dimension_slice_scan_for_existing(DimensionSlice *slice);
 extern DimensionSlice *dimension_slice_scan_by_id(int32 dimension_slice_id, MemoryContext mctx);
 extern DimensionVec *dimension_slice_scan_by_dimension(int32 dimension_id, int limit);

--- a/src/extension_utils.c
+++ b/src/extension_utils.c
@@ -10,7 +10,6 @@
 #include <utils/lsyscache.h>
 #include <miscadmin.h>
 #include <parser/analyze.h>
-#include <commands/extension.h>
 #include <access/relscan.h>
 #include <catalog/pg_extension.h>
 #include <catalog/pg_authid.h>

--- a/src/hypertable.c
+++ b/src/hypertable.c
@@ -180,7 +180,40 @@ hypertable_scan_limit_internal(ScanKeyData *scankey,
 	return scanner_scan(&scanctx);
 }
 
+static bool
+hypertable_tuple_append(TupleInfo *ti, void *data)
+{
+	List	  **hypertables = data;
 
+	*hypertables = lappend(*hypertables, hypertable_from_tuple(ti->tuple, ti->mctx));
+	/* return true tells scanner not to stop, keep calling for all chunks. */
+	return true;
+}
+
+int
+hypertable_get_all(List **result, MemoryContext mctx)
+{
+	Catalog    *catalog = catalog_get();
+	ScannerCtx	scanctx = {
+		.table = catalog->tables[HYPERTABLE].id,
+		.index = InvalidOid,
+		.nkeys = 0,
+		.scankey = NULL,
+		.data = result,
+		.limit = -1,
+		.tuple_found = hypertable_tuple_append,
+		.lockmode = LockTupleKeyShare,
+		.scandirection = ForwardScanDirection,
+		.result_mctx = mctx,
+		.tuplock = {//not sure what correct values here would be
+			.waitpolicy = LockWaitBlock,
+			.lockmode = LockTupleExclusive,
+			.enabled = false,
+		}
+	};
+
+	return scanner_scan(&scanctx);
+}
 static bool
 hypertable_tuple_update(TupleInfo *ti, void *data)
 {
@@ -805,13 +838,21 @@ hypertable_check_associated_schema_permissions(const char *schema_name, Oid user
 }
 
 static bool
-table_has_tuples(Oid table_relid, Snapshot snapshot, LOCKMODE lockmode)
+relation_has_tuples(Relation rel)
 {
-	Relation	rel = heap_open(table_relid, lockmode);
-	HeapScanDesc scandesc = heap_beginscan(rel, snapshot, 0, NULL);
+	HeapScanDesc scandesc = heap_beginscan(rel, GetActiveSnapshot(), 0, NULL);
 	bool		hastuples = HeapTupleIsValid(heap_getnext(scandesc, ForwardScanDirection));
 
 	heap_endscan(scandesc);
+	return hastuples;
+}
+
+static bool
+table_has_tuples(Oid table_relid, LOCKMODE lockmode)
+{
+	Relation	rel = heap_open(table_relid, lockmode);
+	bool		hastuples = relation_has_tuples(rel);
+
 	heap_close(rel, lockmode);
 	return hastuples;
 }
@@ -827,7 +868,7 @@ hypertable_has_tuples(Oid table_relid, LOCKMODE lockmode)
 		Oid			chunk_relid = lfirst_oid(lc);
 
 		/* Chunks already locked by find_inheritance_children() */
-		if (table_has_tuples(chunk_relid, GetActiveSnapshot(), NoLock))
+		if (table_has_tuples(chunk_relid, NoLock))
 			return true;
 	}
 
@@ -940,23 +981,47 @@ hypertable_create(PG_FUNCTION_ARGS)
 	NameData	schema_name,
 				table_name,
 				default_associated_schema_name;
+	Relation	rel;
+
+	/* quick exit in the easy if-not-exists case to avoid all locking */
+	if (if_not_exists && is_hypertable(table_relid))
+	{
+		ereport(NOTICE,
+				(errcode(ERRCODE_IO_HYPERTABLE_EXISTS),
+				 errmsg("table \"%s\" is already a hypertable, skipping",
+						get_rel_name(table_relid))));
+
+		PG_RETURN_VOID();
+	}
 
 	/*
 	 * Serialize hypertable creation to avoid having multiple transactions
 	 * creating the same hypertable simultaneously. The lock should conflict
 	 * with itself and RowExclusive, to prevent simultaneous inserts on the
-	 * table. Hold until transaction end.
+	 * table. Also since TRUNCATE (part of data migrationt) takes an
+	 * AccessExclusiveLock take that lock level here to so that we don't have
+	 * lock upgrades, which are suceptible to deadlocks. If we aren't
+	 * migrating data, then shouldn't have much contention on the table thus
+	 * not worth optimizing.
 	 */
-	LockRelationOid(table_relid, ShareRowExclusiveLock);
+	rel = heap_open(table_relid, AccessExclusiveLock);
 
+	/* recheck after getting lock */
 	if (is_hypertable(table_relid))
 	{
+		/*
+		 * Unlock and return. Note that unlocking is analagous to what PG does
+		 * for ALTER TABLE ADD COLUMN IF NOT EXIST
+		 */
+		heap_close(rel, AccessExclusiveLock);
+
 		if (if_not_exists)
 		{
 			ereport(NOTICE,
 					(errcode(ERRCODE_IO_HYPERTABLE_EXISTS),
 					 errmsg("table \"%s\" is already a hypertable, skipping",
 							get_rel_name(table_relid))));
+
 			PG_RETURN_VOID();
 		}
 
@@ -993,7 +1058,7 @@ hypertable_create(PG_FUNCTION_ARGS)
 	/* Check that the table doesn't have any unsupported constraints */
 	hypertable_validate_constraints(table_relid);
 
-	table_has_data = table_has_tuples(table_relid, GetActiveSnapshot(), NoLock);
+	table_has_data = relation_has_tuples(rel);
 
 	if (!migrate_data && table_has_data)
 		ereport(ERROR,
@@ -1080,7 +1145,14 @@ hypertable_create(PG_FUNCTION_ARGS)
 		tablespace_attach_internal(&tspc_name, table_relid, false);
 	}
 
-	/* Migrate data from the main table to chunks */
+	/*
+	 * Migrate data from the main table to chunks
+	 *
+	 * Note: we do not unlock here. We wait till the end of the txn instead.
+	 * Must close the relation before migrating data.
+	 */
+	heap_close(rel, NoLock);
+
 	if (table_has_data)
 	{
 		ereport(NOTICE,
@@ -1094,6 +1166,5 @@ hypertable_create(PG_FUNCTION_ARGS)
 		indexing_create_default_indexes(ht);
 
 	cache_release(hcache);
-
 	PG_RETURN_VOID();
 }

--- a/src/hypertable.h
+++ b/src/hypertable.h
@@ -11,7 +11,6 @@
 
 typedef struct SubspaceStore SubspaceStore;
 typedef struct Chunk Chunk;
-typedef struct HeapTupleData *HeapTuple;
 
 typedef struct Hypertable
 {
@@ -23,6 +22,7 @@ typedef struct Hypertable
 
 
 extern Oid	rel_get_owner(Oid relid);
+extern int	hypertable_get_all(List **result, MemoryContext mctx);
 extern Hypertable *hypertable_get_by_id(int32 hypertable_id);
 extern Hypertable *hypertable_get_by_name(char *schema, char *name);
 extern bool hypertable_has_privs_of(Oid hypertable_oid, Oid userid);

--- a/src/plan_add_hashagg.c
+++ b/src/plan_add_hashagg.c
@@ -29,7 +29,6 @@
 #include "hypertable_insert.h"
 #include "constraint_aware_append.h"
 #include "compat.h"
-#include "extension.h"
 
 #define INVALID_ESTIMATE -1
 #define IS_VALID_ESTIMATE(est) (est >= 0)

--- a/src/planner.c
+++ b/src/planner.c
@@ -16,7 +16,6 @@
 #include <utils/lsyscache.h>
 #include <executor/nodeAgg.h>
 #include <utils/timestamp.h>
-#include <utils/lsyscache.h>
 #include <utils/selfuncs.h>
 
 #include "compat-msvc-enter.h"

--- a/src/utils.h
+++ b/src/utils.h
@@ -13,6 +13,11 @@
 extern int64 time_value_to_internal(Datum time_val, Oid type, bool failure_ok);
 
 /*
+ * Convert the difference of interval and current timestamp to internal representation
+ */
+extern int64 interval_from_now_to_internal(Datum time_val, Oid type);
+
+/*
  * Return the period in microseconds of the first argument to date_trunc.
  * This is approximate -- to be used for planning;
  */
@@ -38,6 +43,8 @@ extern Oid	inheritance_parent_relid(Oid relid);
 
 #define is_inheritance_table(relid) \
     (is_inheritance_child(relid) || is_inheritance_parent(relid))
+
+Datum		srf_return_list(FunctionCallInfo fcinfo);
 
 #define DATUM_GET(values, attno) \
 	values[attno-1]

--- a/test/expected/chunk_utils.out
+++ b/test/expected/chunk_utils.out
@@ -1,3 +1,13 @@
+CREATE OR REPLACE FUNCTION dimension_get_time(
+    hypertable_id INT
+)
+    RETURNS _timescaledb_catalog.dimension LANGUAGE SQL STABLE AS
+$BODY$
+    SELECT *
+    FROM _timescaledb_catalog.dimension d
+    WHERE d.hypertable_id = dimension_get_time.hypertable_id AND
+          d.interval_length IS NOT NULL
+$BODY$;
 CREATE TABLE PUBLIC.drop_chunk_test1(time bigint, temp float8, device_id text);
 CREATE TABLE PUBLIC.drop_chunk_test2(time bigint, temp float8, device_id text);
 CREATE TABLE PUBLIC.drop_chunk_test3(time bigint, temp float8, device_id text);
@@ -42,10 +52,16 @@ SELECT add_dimension('public.drop_chunk_test3', 'device_id', 2);
  
 (1 row)
 
+--should work becasue so far all tables have time column type of bigint
+SELECT show_chunks();
+ show_chunks 
+-------------
+(0 rows)
+
 SELECT c.id AS chunk_id, c.hypertable_id, c.schema_name AS chunk_schema, c.table_name AS chunk_table, ds.range_start, ds.range_end
 FROM _timescaledb_catalog.chunk c
 INNER JOIN _timescaledb_catalog.hypertable h ON (c.hypertable_id = h.id)
-INNER JOIN  _timescaledb_internal.dimension_get_time(h.id) time_dimension ON(true)
+INNER JOIN  dimension_get_time(h.id) time_dimension ON(true)
 INNER JOIN  _timescaledb_catalog.dimension_slice ds ON (ds.dimension_id = time_dimension.id)
 INNER JOIN  _timescaledb_catalog.chunk_constraint cc ON (cc.dimension_slice_id = ds.id AND cc.chunk_id = c.id)
 WHERE h.schema_name = 'public' AND (h.table_name = 'drop_chunk_test1' OR h.table_name = 'drop_chunk_test2');
@@ -92,7 +108,7 @@ INSERT INTO PUBLIC.drop_chunk_test3 VALUES(6, 6.0, 'dev7');
 SELECT c.id AS chunk_id, c.hypertable_id, c.schema_name AS chunk_schema, c.table_name AS chunk_table, ds.range_start, ds.range_end
 FROM _timescaledb_catalog.chunk c
 INNER JOIN _timescaledb_catalog.hypertable h ON (c.hypertable_id = h.id)
-INNER JOIN  _timescaledb_internal.dimension_get_time(h.id) time_dimension ON(true)
+INNER JOIN  dimension_get_time(h.id) time_dimension ON(true)
 INNER JOIN  _timescaledb_catalog.dimension_slice ds ON (ds.dimension_id = time_dimension.id)
 INNER JOIN  _timescaledb_catalog.chunk_constraint cc ON (cc.dimension_slice_id = ds.id AND cc.chunk_id = c.id)
 WHERE h.schema_name = 'public' AND (h.table_name = 'drop_chunk_test1' OR h.table_name = 'drop_chunk_test2');
@@ -136,11 +152,71 @@ WHERE h.schema_name = 'public' AND (h.table_name = 'drop_chunk_test1' OR h.table
  _timescaledb_internal | _hyper_3_18_chunk | table | default_perm_user
 (18 rows)
 
+-- next two calls of show_chunks should give same set of chunks as above when combined
+SELECT show_chunks('drop_chunk_test1');
+              show_chunks               
+----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+ _timescaledb_internal._hyper_1_5_chunk
+ _timescaledb_internal._hyper_1_6_chunk
+(6 rows)
+
+SELECT * FROM show_chunks('drop_chunk_test2');
+               show_chunks               
+-----------------------------------------
+ _timescaledb_internal._hyper_2_7_chunk
+ _timescaledb_internal._hyper_2_8_chunk
+ _timescaledb_internal._hyper_2_9_chunk
+ _timescaledb_internal._hyper_2_10_chunk
+ _timescaledb_internal._hyper_2_11_chunk
+ _timescaledb_internal._hyper_2_12_chunk
+(6 rows)
+
 CREATE VIEW dependent_view AS SELECT * FROM _timescaledb_internal._hyper_1_1_chunk;
 \set ON_ERROR_STOP 0
 SELECT drop_chunks(2);
 ERROR:  cannot drop table _timescaledb_internal._hyper_1_1_chunk because other objects depend on it
+-- should error because not a time type
+SELECT drop_chunks('haha', 'drop_chunk_test3');
+ERROR:  could not determine polymorphic type because input has type unknown
+SELECT show_chunks('drop_chunk_test3', 'haha');
+ERROR:  time constraint arguments of show_chunks should have one of acceptable time column types: SMALLINT, INT, BIGINT, TIMESTAMP, TIMESTAMPTZ, DATE
+-- should error because wrong time type
+SELECT drop_chunks(now(), 'drop_chunk_test3');
+ERROR:  time constraint arguments of drop_chunks should have same type as time column of the hypertable
+SELECT show_chunks('drop_chunk_test3', now());
+ERROR:  time constraint arguments of show_chunks should have same type as time column of the hypertable
+-- should error because of wrong relative order of time constraints
+SELECT show_chunks('drop_chunk_test1', older_than=>3, newer_than=>4);
+ERROR:  When both older_than and newer_than are specified, older_than must come after newer_than
 \set ON_ERROR_STOP 1
+--should work becasue so far all tables have time column type of bigint
+SELECT show_chunks();
+               show_chunks               
+-----------------------------------------
+ _timescaledb_internal._hyper_1_1_chunk
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+ _timescaledb_internal._hyper_1_5_chunk
+ _timescaledb_internal._hyper_1_6_chunk
+ _timescaledb_internal._hyper_2_7_chunk
+ _timescaledb_internal._hyper_2_8_chunk
+ _timescaledb_internal._hyper_2_9_chunk
+ _timescaledb_internal._hyper_2_10_chunk
+ _timescaledb_internal._hyper_2_11_chunk
+ _timescaledb_internal._hyper_2_12_chunk
+ _timescaledb_internal._hyper_3_13_chunk
+ _timescaledb_internal._hyper_3_14_chunk
+ _timescaledb_internal._hyper_3_15_chunk
+ _timescaledb_internal._hyper_3_16_chunk
+ _timescaledb_internal._hyper_3_17_chunk
+ _timescaledb_internal._hyper_3_18_chunk
+(18 rows)
+
 -- show created constraints and dimension slices for each chunk
 SELECT c.table_name, cc.constraint_name, ds.id AS dimension_slice_id, ds.range_start, ds.range_end
 FROM _timescaledb_catalog.chunk c
@@ -367,7 +443,7 @@ SELECT * FROM _timescaledb_catalog.dimension_slice;
 SELECT c.id AS chunk_id, c.hypertable_id, c.schema_name AS chunk_schema, c.table_name AS chunk_table, ds.range_start, ds.range_end
 FROM _timescaledb_catalog.chunk c
 INNER JOIN _timescaledb_catalog.hypertable h ON (c.hypertable_id = h.id)
-INNER JOIN  _timescaledb_internal.dimension_get_time(h.id) time_dimension ON(true)
+INNER JOIN  dimension_get_time(h.id) time_dimension ON(true)
 INNER JOIN  _timescaledb_catalog.dimension_slice ds ON (ds.dimension_id = time_dimension.id)
 INNER JOIN  _timescaledb_catalog.chunk_constraint cc ON (cc.dimension_slice_id = ds.id AND cc.chunk_id = c.id)
 WHERE h.schema_name = 'public' AND (h.table_name = 'drop_chunk_test1' OR h.table_name = 'drop_chunk_test2');
@@ -384,6 +460,27 @@ WHERE h.schema_name = 'public' AND (h.table_name = 'drop_chunk_test1' OR h.table
        11 |             2 | _timescaledb_internal | _hyper_2_11_chunk |           5 |         6
        12 |             2 | _timescaledb_internal | _hyper_2_12_chunk |           6 |         7
 (10 rows)
+
+-- next two calls of show_chunks should give same set of chunks as above when combined
+SELECT show_chunks('drop_chunk_test1');
+              show_chunks               
+----------------------------------------
+ _timescaledb_internal._hyper_1_2_chunk
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+ _timescaledb_internal._hyper_1_5_chunk
+ _timescaledb_internal._hyper_1_6_chunk
+(5 rows)
+
+SELECT * FROM show_chunks('drop_chunk_test2');
+               show_chunks               
+-----------------------------------------
+ _timescaledb_internal._hyper_2_8_chunk
+ _timescaledb_internal._hyper_2_9_chunk
+ _timescaledb_internal._hyper_2_10_chunk
+ _timescaledb_internal._hyper_2_11_chunk
+ _timescaledb_internal._hyper_2_12_chunk
+(5 rows)
 
 \dt "_timescaledb_internal".*
                            List of relations
@@ -415,7 +512,7 @@ SELECT drop_chunks(3, 'drop_chunk_test1');
 SELECT c.id AS chunk_id, c.hypertable_id, c.schema_name AS chunk_schema, c.table_name AS chunk_table, ds.range_start, ds.range_end
 FROM _timescaledb_catalog.chunk c
 INNER JOIN _timescaledb_catalog.hypertable h ON (c.hypertable_id = h.id)
-INNER JOIN  _timescaledb_internal.dimension_get_time(h.id) time_dimension ON(true)
+INNER JOIN  dimension_get_time(h.id) time_dimension ON(true)
 INNER JOIN  _timescaledb_catalog.dimension_slice ds ON (ds.dimension_id = time_dimension.id)
 INNER JOIN  _timescaledb_catalog.chunk_constraint cc ON (cc.dimension_slice_id = ds.id AND cc.chunk_id = c.id)
 WHERE h.schema_name = 'public' AND (h.table_name = 'drop_chunk_test1' OR h.table_name = 'drop_chunk_test2');
@@ -431,6 +528,26 @@ WHERE h.schema_name = 'public' AND (h.table_name = 'drop_chunk_test1' OR h.table
        11 |             2 | _timescaledb_internal | _hyper_2_11_chunk |           5 |         6
        12 |             2 | _timescaledb_internal | _hyper_2_12_chunk |           6 |         7
 (9 rows)
+
+-- next two calls of show_chunks should give same set of chunks as above when combined
+SELECT show_chunks('drop_chunk_test1');
+              show_chunks               
+----------------------------------------
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+ _timescaledb_internal._hyper_1_5_chunk
+ _timescaledb_internal._hyper_1_6_chunk
+(4 rows)
+
+SELECT * FROM show_chunks('drop_chunk_test2');
+               show_chunks               
+-----------------------------------------
+ _timescaledb_internal._hyper_2_8_chunk
+ _timescaledb_internal._hyper_2_9_chunk
+ _timescaledb_internal._hyper_2_10_chunk
+ _timescaledb_internal._hyper_2_11_chunk
+ _timescaledb_internal._hyper_2_12_chunk
+(5 rows)
 
 \dt "_timescaledb_internal".*
                            List of relations
@@ -462,7 +579,7 @@ SELECT drop_chunks(2147483648, 'drop_chunk_test3');
 SELECT c.id AS chunk_id, c.hypertable_id, c.schema_name AS chunk_schema, c.table_name AS chunk_table, ds.range_start, ds.range_end
 FROM _timescaledb_catalog.chunk c
 INNER JOIN _timescaledb_catalog.hypertable h ON (c.hypertable_id = h.id)
-INNER JOIN  _timescaledb_internal.dimension_get_time(h.id) time_dimension ON(true)
+INNER JOIN  dimension_get_time(h.id) time_dimension ON(true)
 INNER JOIN  _timescaledb_catalog.dimension_slice ds ON (ds.dimension_id = time_dimension.id)
 INNER JOIN  _timescaledb_catalog.chunk_constraint cc ON (cc.dimension_slice_id = ds.id AND cc.chunk_id = c.id)
 WHERE h.schema_name = 'public' AND (h.table_name = 'drop_chunk_test1' OR h.table_name = 'drop_chunk_test2' OR h.table_name = 'drop_chunk_test3');
@@ -494,16 +611,20 @@ WHERE h.schema_name = 'public' AND (h.table_name = 'drop_chunk_test1' OR h.table
  _timescaledb_internal | _hyper_2_9_chunk  | table | default_perm_user
 (9 rows)
 
--- should error because no hypertable
 \set ON_ERROR_STOP 0
+-- should error because no hypertable
 SELECT drop_chunks(5, 'drop_chunk_test4');
-ERROR:  no hypertables found
+ERROR:  hypertable "drop_chunk_test4" does not exist
+SELECT show_chunks('drop_chunk_test4');
+ERROR:  relation "drop_chunk_test4" does not exist at character 20
+SELECT show_chunks('drop_chunk_test4', 5);
+ERROR:  relation "drop_chunk_test4" does not exist at character 20
 \set ON_ERROR_STOP 1
 DROP TABLE _timescaledb_internal._hyper_1_6_chunk;
 SELECT c.id AS chunk_id, c.hypertable_id, c.schema_name AS chunk_schema, c.table_name AS chunk_table, ds.range_start, ds.range_end
 FROM _timescaledb_catalog.chunk c
 INNER JOIN _timescaledb_catalog.hypertable h ON (c.hypertable_id = h.id)
-INNER JOIN  _timescaledb_internal.dimension_get_time(h.id) time_dimension ON(true)
+INNER JOIN  dimension_get_time(h.id) time_dimension ON(true)
 INNER JOIN  _timescaledb_catalog.dimension_slice ds ON (ds.dimension_id = time_dimension.id)
 INNER JOIN  _timescaledb_catalog.chunk_constraint cc ON (cc.dimension_slice_id = ds.id AND cc.chunk_id = c.id)
 WHERE h.schema_name = 'public' AND (h.table_name = 'drop_chunk_test1' OR h.table_name = 'drop_chunk_test2');
@@ -532,6 +653,116 @@ WHERE h.schema_name = 'public' AND (h.table_name = 'drop_chunk_test1' OR h.table
  _timescaledb_internal | _hyper_2_8_chunk  | table | default_perm_user
  _timescaledb_internal | _hyper_2_9_chunk  | table | default_perm_user
 (8 rows)
+
+-- newer_than tests
+SELECT drop_chunks(table_name=>'drop_chunk_test1', newer_than=>5);
+ drop_chunks 
+-------------
+ 
+(1 row)
+
+SELECT c.id AS chunk_id, c.hypertable_id, c.schema_name AS chunk_schema, c.table_name AS chunk_table, ds.range_start, ds.range_end
+FROM _timescaledb_catalog.chunk c
+INNER JOIN _timescaledb_catalog.hypertable h ON (c.hypertable_id = h.id)
+INNER JOIN  dimension_get_time(h.id) time_dimension ON(true)
+INNER JOIN  _timescaledb_catalog.dimension_slice ds ON (ds.dimension_id = time_dimension.id)
+INNER JOIN  _timescaledb_catalog.chunk_constraint cc ON (cc.dimension_slice_id = ds.id AND cc.chunk_id = c.id)
+WHERE h.schema_name = 'public' AND (h.table_name = 'drop_chunk_test1');
+ chunk_id | hypertable_id |     chunk_schema      |   chunk_table    | range_start | range_end 
+----------+---------------+-----------------------+------------------+-------------+-----------
+        3 |             1 | _timescaledb_internal | _hyper_1_3_chunk |           3 |         4
+        4 |             1 | _timescaledb_internal | _hyper_1_4_chunk |           4 |         5
+(2 rows)
+
+SELECT show_chunks('drop_chunk_test1');
+              show_chunks               
+----------------------------------------
+ _timescaledb_internal._hyper_1_3_chunk
+ _timescaledb_internal._hyper_1_4_chunk
+(2 rows)
+
+\dt "_timescaledb_internal".*
+                           List of relations
+        Schema         |       Name        | Type  |       Owner       
+-----------------------+-------------------+-------+-------------------
+ _timescaledb_internal | _hyper_1_3_chunk  | table | default_perm_user
+ _timescaledb_internal | _hyper_1_4_chunk  | table | default_perm_user
+ _timescaledb_internal | _hyper_2_10_chunk | table | default_perm_user
+ _timescaledb_internal | _hyper_2_11_chunk | table | default_perm_user
+ _timescaledb_internal | _hyper_2_12_chunk | table | default_perm_user
+ _timescaledb_internal | _hyper_2_8_chunk  | table | default_perm_user
+ _timescaledb_internal | _hyper_2_9_chunk  | table | default_perm_user
+(7 rows)
+
+SELECT drop_chunks(table_name=>'drop_chunk_test1', older_than=>4, newer_than=>3);
+ drop_chunks 
+-------------
+ 
+(1 row)
+
+SELECT c.id AS chunk_id, c.hypertable_id, c.schema_name AS chunk_schema, c.table_name AS chunk_table, ds.range_start, ds.range_end
+FROM _timescaledb_catalog.chunk c
+INNER JOIN _timescaledb_catalog.hypertable h ON (c.hypertable_id = h.id)
+INNER JOIN  dimension_get_time(h.id) time_dimension ON(true)
+INNER JOIN  _timescaledb_catalog.dimension_slice ds ON (ds.dimension_id = time_dimension.id)
+INNER JOIN  _timescaledb_catalog.chunk_constraint cc ON (cc.dimension_slice_id = ds.id AND cc.chunk_id = c.id)
+WHERE h.schema_name = 'public' AND (h.table_name = 'drop_chunk_test1');
+ chunk_id | hypertable_id |     chunk_schema      |   chunk_table    | range_start | range_end 
+----------+---------------+-----------------------+------------------+-------------+-----------
+        4 |             1 | _timescaledb_internal | _hyper_1_4_chunk |           4 |         5
+(1 row)
+
+-- the call of show_chunks should give same set of chunks as above
+SELECT show_chunks('drop_chunk_test1');
+              show_chunks               
+----------------------------------------
+ _timescaledb_internal._hyper_1_4_chunk
+(1 row)
+
+-- testing drop_chunks when only schema is specified.
+\set ON_ERROR_STOP 0
+SELECT drop_chunks(schema_name=>'public');
+ERROR:  could not determine polymorphic type because input has type unknown
+SELECT drop_chunks(null::bigint, schema_name=>'public');
+ERROR:  Both older_than and newer_than timestamps provided to drop_chunks cannot be NULL
+\set ON_ERROR_STOP 1
+SELECT c.id AS chunk_id, c.hypertable_id, c.schema_name AS chunk_schema, c.table_name AS chunk_table, ds.range_start, ds.range_end
+FROM _timescaledb_catalog.chunk c
+INNER JOIN _timescaledb_catalog.hypertable h ON (c.hypertable_id = h.id)
+INNER JOIN  dimension_get_time(h.id) time_dimension ON(true)
+INNER JOIN  _timescaledb_catalog.dimension_slice ds ON (ds.dimension_id = time_dimension.id)
+INNER JOIN  _timescaledb_catalog.chunk_constraint cc ON (cc.dimension_slice_id = ds.id AND cc.chunk_id = c.id)
+WHERE h.schema_name = 'public';
+ chunk_id | hypertable_id |     chunk_schema      |    chunk_table    | range_start | range_end 
+----------+---------------+-----------------------+-------------------+-------------+-----------
+        4 |             1 | _timescaledb_internal | _hyper_1_4_chunk  |           4 |         5
+        8 |             2 | _timescaledb_internal | _hyper_2_8_chunk  |           2 |         3
+        9 |             2 | _timescaledb_internal | _hyper_2_9_chunk  |           3 |         4
+       10 |             2 | _timescaledb_internal | _hyper_2_10_chunk |           4 |         5
+       11 |             2 | _timescaledb_internal | _hyper_2_11_chunk |           5 |         6
+       12 |             2 | _timescaledb_internal | _hyper_2_12_chunk |           6 |         7
+(6 rows)
+
+SELECT drop_chunks(5, schema_name=>'public', newer_than=>4);
+ drop_chunks 
+-------------
+ 
+(1 row)
+
+SELECT c.id AS chunk_id, c.hypertable_id, c.schema_name AS chunk_schema, c.table_name AS chunk_table, ds.range_start, ds.range_end
+FROM _timescaledb_catalog.chunk c
+INNER JOIN _timescaledb_catalog.hypertable h ON (c.hypertable_id = h.id)
+INNER JOIN  dimension_get_time(h.id) time_dimension ON(true)
+INNER JOIN  _timescaledb_catalog.dimension_slice ds ON (ds.dimension_id = time_dimension.id)
+INNER JOIN  _timescaledb_catalog.chunk_constraint cc ON (cc.dimension_slice_id = ds.id AND cc.chunk_id = c.id)
+WHERE h.schema_name = 'public';
+ chunk_id | hypertable_id |     chunk_schema      |    chunk_table    | range_start | range_end 
+----------+---------------+-----------------------+-------------------+-------------+-----------
+        8 |             2 | _timescaledb_internal | _hyper_2_8_chunk  |           2 |         3
+        9 |             2 | _timescaledb_internal | _hyper_2_9_chunk  |           3 |         4
+       11 |             2 | _timescaledb_internal | _hyper_2_11_chunk |           5 |         6
+       12 |             2 | _timescaledb_internal | _hyper_2_12_chunk |           6 |         7
+(4 rows)
 
 CREATE TABLE PUBLIC.drop_chunk_test_ts(time timestamp, temp float8, device_id text);
 SELECT create_hypertable('public.drop_chunk_test_ts', 'time', chunk_time_interval => interval '1 minute', create_default_indexes=>false);
@@ -564,6 +795,96 @@ SELECT * FROM test.show_subtables('drop_chunk_test_tstz');
  _timescaledb_internal._hyper_5_20_chunk | 
 (1 row)
 
+BEGIN;
+    SELECT show_chunks('drop_chunk_test_ts');
+               show_chunks               
+-----------------------------------------
+ _timescaledb_internal._hyper_4_19_chunk
+(1 row)
+
+    SELECT show_chunks('drop_chunk_test_ts', now()::timestamp-interval '1 minute');
+               show_chunks               
+-----------------------------------------
+ _timescaledb_internal._hyper_4_19_chunk
+(1 row)
+
+    SELECT drop_chunks(newer_than => interval '1 minute', table_name => 'drop_chunk_test_ts');
+ drop_chunks 
+-------------
+ 
+(1 row)
+
+    SELECT drop_chunks(older_than => interval '6 minute', table_name => 'drop_chunk_test_ts');
+ drop_chunks 
+-------------
+ 
+(1 row)
+
+    SELECT * FROM test.show_subtables('drop_chunk_test_ts');
+                  Child                  | Tablespace 
+-----------------------------------------+------------
+ _timescaledb_internal._hyper_4_19_chunk | 
+(1 row)
+
+    SELECT drop_chunks(interval '1 minute', 'drop_chunk_test_ts');
+ drop_chunks 
+-------------
+ 
+(1 row)
+
+    SELECT * FROM test.show_subtables('drop_chunk_test_ts');
+ Child | Tablespace 
+-------+------------
+(0 rows)
+
+    SELECT show_chunks('drop_chunk_test_tstz');
+               show_chunks               
+-----------------------------------------
+ _timescaledb_internal._hyper_5_20_chunk
+(1 row)
+
+    SELECT show_chunks('drop_chunk_test_tstz', now() - interval '1 minute', now() - interval '6 minute');
+               show_chunks               
+-----------------------------------------
+ _timescaledb_internal._hyper_5_20_chunk
+(1 row)
+
+    SELECT show_chunks('drop_chunk_test_tstz', newer_than => now() - interval '1 minute');
+ show_chunks 
+-------------
+(0 rows)
+
+    SELECT show_chunks('drop_chunk_test_tstz', older_than => now() - interval '1 minute');
+               show_chunks               
+-----------------------------------------
+ _timescaledb_internal._hyper_5_20_chunk
+(1 row)
+
+    SELECT drop_chunks(interval '1 minute', 'drop_chunk_test_tstz');
+ drop_chunks 
+-------------
+ 
+(1 row)
+
+    SELECT * FROM test.show_subtables('drop_chunk_test_tstz');
+ Child | Tablespace 
+-------+------------
+(0 rows)
+
+ROLLBACK;
+BEGIN;
+    SELECT drop_chunks(newer_than => interval '6 minute', table_name => 'drop_chunk_test_ts');
+ drop_chunks 
+-------------
+ 
+(1 row)
+
+    SELECT * FROM test.show_subtables('drop_chunk_test_ts');
+ Child | Tablespace 
+-------+------------
+(0 rows)
+
+ROLLBACK;
 BEGIN;
     SELECT drop_chunks(interval '1 minute', 'drop_chunk_test_ts');
  drop_chunks 
@@ -612,16 +933,55 @@ BEGIN;
 (0 rows)
 
 ROLLBACK;
+\dt "_timescaledb_internal".*
+                           List of relations
+        Schema         |       Name        | Type  |       Owner       
+-----------------------+-------------------+-------+-------------------
+ _timescaledb_internal | _hyper_2_11_chunk | table | default_perm_user
+ _timescaledb_internal | _hyper_2_12_chunk | table | default_perm_user
+ _timescaledb_internal | _hyper_2_8_chunk  | table | default_perm_user
+ _timescaledb_internal | _hyper_2_9_chunk  | table | default_perm_user
+ _timescaledb_internal | _hyper_4_19_chunk | table | default_perm_user
+ _timescaledb_internal | _hyper_5_20_chunk | table | default_perm_user
+(6 rows)
+
+SELECT show_chunks();
+               show_chunks               
+-----------------------------------------
+ _timescaledb_internal._hyper_2_8_chunk
+ _timescaledb_internal._hyper_2_9_chunk
+ _timescaledb_internal._hyper_2_11_chunk
+ _timescaledb_internal._hyper_2_12_chunk
+ _timescaledb_internal._hyper_4_19_chunk
+ _timescaledb_internal._hyper_5_20_chunk
+(6 rows)
+
 \set ON_ERROR_STOP 0
+SELECT drop_chunks(4);
+ERROR:  time constraint arguments of drop_chunks should have same type as time column of the hypertable
 SELECT drop_chunks(interval '1 minute');
-ERROR:  cannot use drop_chunks on multiple tables with different time types
+ERROR:  can only use drop_chunks with an INTERVAL for TIMESTAMP, TIMESTAMPTZ, and DATE types
 SELECT drop_chunks(interval '1 minute', 'drop_chunk_test3');
 ERROR:  can only use drop_chunks with an INTERVAL for TIMESTAMP, TIMESTAMPTZ, and DATE types
 SELECT drop_chunks(now()-interval '1 minute', 'drop_chunk_test_ts');
-ERROR:  cannot call drop_chunks with a timestamp with time zone on hypertables with a time type of: timestamp without time zone
+ERROR:  time constraint arguments of drop_chunks should have same type as time column of the hypertable
 SELECT drop_chunks(now()::timestamp-interval '1 minute', 'drop_chunk_test_tstz');
-ERROR:  cannot call drop_chunks with a timestamp without time zone on hypertables with a time type of: timestamp with time zone
+ERROR:  time constraint arguments of drop_chunks should have same type as time column of the hypertable
+SELECT drop_chunks(5, schema_name=>'public', newer_than=>4);
+ERROR:  time constraint arguments of drop_chunks should have same type as time column of the hypertable
 \set ON_ERROR_STOP 1
+\dt "_timescaledb_internal".*
+                           List of relations
+        Schema         |       Name        | Type  |       Owner       
+-----------------------+-------------------+-------+-------------------
+ _timescaledb_internal | _hyper_2_11_chunk | table | default_perm_user
+ _timescaledb_internal | _hyper_2_12_chunk | table | default_perm_user
+ _timescaledb_internal | _hyper_2_8_chunk  | table | default_perm_user
+ _timescaledb_internal | _hyper_2_9_chunk  | table | default_perm_user
+ _timescaledb_internal | _hyper_4_19_chunk | table | default_perm_user
+ _timescaledb_internal | _hyper_5_20_chunk | table | default_perm_user
+(6 rows)
+
 CREATE TABLE PUBLIC.drop_chunk_test_date(time date, temp float8, device_id text);
 SELECT create_hypertable('public.drop_chunk_test_date', 'time', chunk_time_interval => interval '1 day', create_default_indexes=>false);
 NOTICE:  adding not-null constraint to column "time"

--- a/test/expected/extension.out
+++ b/test/expected/extension.out
@@ -29,7 +29,8 @@ ORDER BY proname;
  last
  set_chunk_time_interval
  set_number_partitions
+ show_chunks
  show_tablespaces
  time_bucket
-(20 rows)
+(21 rows)
 

--- a/test/expected/pg_dump.out
+++ b/test/expected/pg_dump.out
@@ -53,7 +53,7 @@ SELECT count(*)
      AND refobjid = (SELECT oid FROM pg_extension WHERE extname = 'timescaledb');
  count 
 -------
-    94
+    93
 (1 row)
 
 SELECT * FROM test.show_columns('"test_schema"."two_Partitions"');
@@ -239,7 +239,7 @@ SELECT count(*)
      AND refobjid = (SELECT oid FROM pg_extension WHERE extname = 'timescaledb');
  count 
 -------
-    94
+    93
 (1 row)
 
 --main table and chunk schemas should be the same

--- a/test/sql/CMakeLists.txt
+++ b/test/sql/CMakeLists.txt
@@ -5,6 +5,7 @@ set(TEST_FILES
   append.sql
   append_unoptimized.sql
   append_x_diff.sql
+  chunk_utils.sql
   chunks.sql
   cluster.sql
   constraint.sql
@@ -19,7 +20,6 @@ set(TEST_FILES
   delete.sql
   drop_schema.sql
   drop_owned.sql
-  drop_chunks.sql
   drop_extension.sql
   drop_hypertable.sql
   drop_rename_hypertable.sql


### PR DESCRIPTION
Timescale provides an efficient and easy to sue api to drop individual
chunks from timescale database through drop_chunks. This PR builds on
that functionality and through a new export_chunks function gives the
opportunity to see the chunks that would be dropped if drop_chunks were run.
Additionally, it adds a newer_than option to drop_chunks (also supported
by export_chunks) that allows to see/drop chunks in an interval or newer
than a point in time.

This commit includes:
    - Implementation of show_chunks in C
    - Additional helper functions to work with chunks
    - New version of drop_chunks in sql that uses show_chunks. This
      	  also adds a newer_than option to drop_chunks
    - More enhanced tests of drop_chunks and new tests for show_chunks

The initial plan was to also have export_chunks as part of this commit but
that needs further discussion. show_chunks was implemented in C in order
to be able to have both older_than and newer_than arguments be null. This
was not possible in SQL because the arguments had to have polymorphic types
and whether they are used in function body or not, PL/pgSQL requires these
arguments to typecheck.

The approach before was to have a C relay function that then called an SQL polymorphic function which worked just fine but was too complex for what it did that is why I reimplemented all of show_chunks in C.

Similarly, export_chunks has 2 time arguments which, I assume, we would want
to be optional. If this is the case a relay of export_chunks or all of it has
to be implemented in C.

This is an intermediate PR to discuss my current implementation and discuss the approach
 we want to take for `export chunks`